### PR TITLE
Fixed hazard manager and Enemy spawner

### DIFF
--- a/Assets/Scripts/Cards/HazardCard.cs
+++ b/Assets/Scripts/Cards/HazardCard.cs
@@ -18,18 +18,18 @@ namespace ILOVEYOU
             [Header("Temporary Hazard Creation")]
             [Tooltip("If this hazard card should create extra hazards around the player")][SerializeField] private bool m_createObjects = false;
             [Tooltip("How many objects to create")] [SerializeField] private int m_objectCount = 0;
+            [Tooltip("How long the object will last for. 0 seconds will enable the hazard without it turning off.")][SerializeField] private float m_objectLifetime = 1f;
             [Tooltip("Hazard objects that will be created in the scene around the player")] [SerializeField] private GameObject[] m_hazardObjects;
             [Tooltip("Mask that the hazards will collide with when spawning")][SerializeField] private LayerMask m_mask;
             public void ExecuteEvents(object[] data)
             {
                 PlayerManager player = (PlayerManager)data[1];
-                GameManager gm = (GameManager)data[0];
-
+                
                 //creates the requested objects if true
                 if (m_createObjects)
                 {
                     //gets the position of the player
-                    Vector3 enemyPos = gm.GetOtherPlayer(player).transform.position;
+                    Vector3 enemyPos = GameManager.Instance.GetOtherPlayer(player).transform.position;
 
                     for (int i = 0; i < m_objectCount; i++)
                     {
@@ -53,7 +53,8 @@ namespace ILOVEYOU
                             continue;
                         }
 
-                        gm.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().AddHazard(obj.GetComponent<HazardObject>(), m_time);
+                        if (m_objectLifetime > 0) GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().AddHazard(obj.GetComponent<HazardObject>(), m_objectLifetime);
+                        else GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().AddHazard(obj.GetComponent<HazardObject>());
                     }
                 }
 
@@ -62,9 +63,9 @@ namespace ILOVEYOU
                 if (m_hazardType.Length == 0)
                 {
                     //if time is inputted, activate hazards for set amount of time
-                    if(m_time > 0) gm.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableAllHazards(m_time);
+                    if(m_time > 0) GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableAllHazards(m_time);
                     //else toggle all hazards on
-                    else gm.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableAllHazards();
+                    else GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableAllHazards();
                 }
                 else
                 {
@@ -73,7 +74,7 @@ namespace ILOVEYOU
                     {
                         foreach (HazardTypes type in m_hazardType)
                         {
-                            gm.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableTypeHazards(type, m_time);
+                            GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableTypeHazards(type, m_time);
                         }
                     }
                     //else toggle all hazards on
@@ -81,7 +82,7 @@ namespace ILOVEYOU
                     {
                         foreach (HazardTypes type in m_hazardType)
                         {
-                            gm.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableTypeHazards(type);
+                            GameManager.Instance.GetOtherPlayer(player).GetLevelManager.GetComponent<HazardManager>().EnableTypeHazards(type);
                         }
                     }
                 }

--- a/Assets/Scripts/EnemySystem/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySystem/EnemySpawner.cs
@@ -64,7 +64,6 @@ namespace ILOVEYOU
 
                 for (int i = 0; i < enemyCount; i++)
                 {
-                    //float angle = Random.Range(0f, 1f) * Mathf.PI * 2f;
 
                     if(_SpawnEnemy(m_enemyGroups[groupNumber].RandomEnemyPrefab())) m_onSpawnEnemy.Invoke();
                 }
@@ -79,11 +78,7 @@ namespace ILOVEYOU
 
                 for (int i = 0; i < enemyCount; i++)
                 {
-                    //float angle = Random.Range(0f, 1f) * Mathf.PI * 2f;
-
                     if (_SpawnEnemy(m_enemyGroups[groupNumber].RandomEnemyPrefab())) m_onSpawnEnemy.Invoke();
-
-                    m_onSpawnEnemy.Invoke();
                 }
             }
             /// <summary>
@@ -92,15 +87,7 @@ namespace ILOVEYOU
             /// <param name="groupNumber">enemy group to spawn from</param>
             public void SpawnRandomEnemyFromGroup(int groupNumber)
             {
-                float angle = Random.Range(0f,1f) * Mathf.PI * 2f;
-
-                GameObject enemy = Instantiate(m_enemyGroups[groupNumber].RandomEnemyPrefab());
-                enemy.GetComponent<Enemy>().Initialize(transform);
-
-                enemy.transform.position = new(transform.position.x + (Mathf.Cos(angle) * m_spawnRange), transform.position.y,
-                    transform.position.z + (Mathf.Sin(angle) * m_spawnRange));
-
-                m_onSpawnEnemy.Invoke();
+                if (_SpawnEnemy(m_enemyGroups[groupNumber].RandomEnemyPrefab())) m_onSpawnEnemy.Invoke();
             }
             /// <summary>
             /// spawns a singular specified enemy from a group
@@ -109,14 +96,7 @@ namespace ILOVEYOU
             /// <param name="prefabIndex">which enemy from the array to spawn</param>
             public void SpawnEnemyFromGroup(int groupNumber, int prefabIndex)
             {
-                float angle = Random.Range(0f, 1f) * Mathf.PI * 2f;
-
-                GameObject enemy = Instantiate(m_enemyGroups[groupNumber].EnemyPrefab(prefabIndex));
-
-                enemy.transform.position = new(transform.position.x + (Mathf.Cos(angle) * m_spawnRange), transform.position.y,
-                    transform.position.z + (Mathf.Sin(angle) * m_spawnRange));
-
-                m_onSpawnEnemy.Invoke();
+                if(_SpawnEnemy(m_enemyGroups[groupNumber].EnemyPrefab(prefabIndex))) m_onSpawnEnemy.Invoke();
             }
 
             public void OnDrawGizmos()

--- a/Assets/Scripts/Environment/Hazards/HazardManager.cs
+++ b/Assets/Scripts/Environment/Hazards/HazardManager.cs
@@ -28,7 +28,7 @@ namespace ILOVEYOU
             {
                 if (m_debugging) Debug.Log($"Starting {this}.");
                 //Get all the hazards in the level.
-                m_levelHazards = transform.parent.GetComponentsInChildren<HazardObject>();
+                m_levelHazards = m_hazardContainer.GetComponentsInChildren<HazardObject>();
 
 
                 if (m_levelHazards.Length == 0)


### PR DESCRIPTION
- Fixed error in Hazard manager caused by previous changes in main resetting
- Cleaned up enemy spawner by making all functions use _SpawnEnemy
- Removed cases in enemy spawner where m_onspawnEnemy was getting called twice
- Hazard Cards now have seperate times for spawning in temp hazards. This allows for exit animations and such.