### PR TITLE
Added turn speed to enemies + fixes

### DIFF
--- a/Assets/Prefabs/Enemies/Templates/LungeEnemy.prefab
+++ b/Assets/Prefabs/Enemies/Templates/LungeEnemy.prefab
@@ -84,6 +84,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_speed: 5
+  m_turnSpeed: 3
   m_damage: 1
   m_health: 10
   m_distanceCondition: 5

--- a/Assets/Prefabs/Level/ReduxLevel.prefab
+++ b/Assets/Prefabs/Level/ReduxLevel.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 3013914429574302662}
   - component: {fileID: 278686052850543445}
   - component: {fileID: 2701122190455423552}
-  m_Layer: 11
+  m_Layer: 12
   m_Name: Ground
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/EnemySystem/Enemy Child Scripts/LungeEnemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy Child Scripts/LungeEnemy.cs
@@ -47,7 +47,7 @@ namespace ILOVEYOU
                 Vector3 relativePos = m_playerTransform.position - transform.position;
                 //looks at the player (removing x, and z rotation)
                 Quaternion rotation = Quaternion.LookRotation(relativePos, Vector3.up);
-                rotation = Quaternion.Euler(0f, Mathf.LerpAngle(transform.rotation.eulerAngles.y, rotation.eulerAngles.y, Time.deltaTime), 0f);
+                rotation = Quaternion.Euler(0f, Mathf.LerpAngle(transform.rotation.eulerAngles.y, rotation.eulerAngles.y, Time.deltaTime * m_turnSpeed), 0f);
 
                 transform.rotation = rotation;
 

--- a/Assets/Scripts/EnemySystem/Enemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy.cs
@@ -10,9 +10,11 @@ namespace ILOVEYOU
         public class Enemy : MonoBehaviour
         {
             [SerializeField] protected float m_speed = 1f;
+            [SerializeField] protected float m_turnSpeed = 3f;
             [SerializeField] protected float m_damage = 1f;
             [SerializeField] protected float m_health = 1f;
             [SerializeField] protected float m_distanceCondition = 1f;
+            
             protected Transform m_playerTransform;
             protected Rigidbody m_rigidBody;
             //this is used for the enemy hurtbox script
@@ -48,7 +50,7 @@ namespace ILOVEYOU
                 Vector3 relativePos = m_playerTransform.position - transform.position;
                 //looks at the player (removing x, and z rotation)
                 Quaternion rotation = Quaternion.LookRotation(relativePos, Vector3.up);
-                rotation = Quaternion.Euler(0f, Mathf.LerpAngle(transform.rotation.eulerAngles.y,rotation.eulerAngles.y, Time.deltaTime * 3f), 0f);
+                rotation = Quaternion.Euler(0f, Mathf.LerpAngle(transform.rotation.eulerAngles.y,rotation.eulerAngles.y, Time.deltaTime * m_turnSpeed), 0f);
                 //moves and rotates the enemy
                 //transform.SetPositionAndRotation(transform.position + (m_speed * Time.deltaTime * transform.forward), rotation);
                 m_rigidBody.MoveRotation(rotation);

--- a/Assets/Scripts/EnemySystem/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySystem/EnemySpawner.cs
@@ -110,8 +110,6 @@ namespace ILOVEYOU
 
                 //creates enemy from given prefab
                 GameObject enemy = Instantiate(prefab);
-                //intializes enemy script
-                enemy.GetComponent<Enemy>().Initialize(transform);
                 //attempts 100 times to spawn an enemy
                 for (int i = 0; i < 100; i++)
                 {
@@ -122,6 +120,8 @@ namespace ILOVEYOU
                     //checks if the enemy is colliding with anything
                     if(!Physics.CheckSphere(enemy.transform.position, 1f, m_spawnMask))
                     {
+                        //intializes enemy script
+                        enemy.GetComponent<Enemy>().Initialize(transform);
                         return true;
                     }
                 }


### PR DESCRIPTION
- Enemies can now have their turn speed adjusted
- Fixed enemy spawning by changing floor collider's layer to new layer
- Enemies now only initialize once being successfully spawned