### PR TITLE
Enemy modifiers

### DIFF
--- a/Assets/Editor/GameSettingsEditor.cs
+++ b/Assets/Editor/GameSettingsEditor.cs
@@ -31,6 +31,8 @@ namespace ILOVEYOU.EditorScript
         SerializedProperty m_spawnRangeMaxProp;
         SerializedProperty m_spawnTimeProp;
         SerializedProperty m_spawnCapProp;
+        SerializedProperty m_modListProp;
+        SerializedProperty m_modChanceProp;
         SerializedProperty m_colorsProp;
         //Dictionary<string, object> SavedValues = new();
         //bool cardsEnabled = true;
@@ -102,6 +104,26 @@ namespace ILOVEYOU.EditorScript
             }
         }
         bool m_displayEnemySettings = false;
+        bool m_displayEnemyModifiers = false;
+        bool m_usingEnemyModifiers
+        {
+            get { return m_modListProp.arraySize > 0; }
+            set
+            {
+                switch (value)
+                {
+                    case true:
+                        if (m_modListProp.arraySize == 0)
+                        {
+                            m_modListProp.InsertArrayElementAtIndex(0);
+                        }
+                        break;
+                    case false:
+                        m_modListProp.ClearArray();
+                        break;
+                }
+            }
+        }
         bool m_displayColorStyles = false;
         private void OnEnable()
         {
@@ -128,6 +150,8 @@ namespace ILOVEYOU.EditorScript
             m_spawnRangeMaxProp = serializedObject.FindProperty("m_spawnRangeMax");
             m_spawnTimeProp = serializedObject.FindProperty("m_spawnTime");
             m_spawnCapProp = serializedObject.FindProperty("m_spawnCap");
+            m_modListProp = serializedObject.FindProperty("m_modList");
+            m_modChanceProp = serializedObject.FindProperty("m_modChanceOverTime");
             m_colorsProp = serializedObject.FindProperty("m_prefColors");
         }
         public override void OnInspectorGUI()
@@ -296,6 +320,27 @@ namespace ILOVEYOU.EditorScript
                     EditorGUILayout.LabelField("Enemy spawn rate and cap");
                     EditorGUILayout.PropertyField(m_spawnTimeProp, new GUIContent("Rate"));
                     EditorGUILayout.PropertyField(m_spawnCapProp, new GUIContent("Cap"));
+                }
+
+                if (m_usingEnemyModifiers)
+                {
+                    m_displayEnemyModifiers =  EditorGUILayout.Foldout(m_displayEnemyModifiers, new GUIContent("Enemy Modifiers"));
+                    if (m_displayEnemyModifiers)
+                    {
+                        EditorGUILayout.PropertyField(m_modListProp, new GUIContent("Mod list"));
+                        EditorGUILayout.PropertyField(m_modChanceProp, new GUIContent("Mod chance"));
+                        if(GUILayout.Button("Remove Enemy Modifiers"))
+                        {
+                            m_usingEnemyModifiers = false;
+                        }
+                    }
+                }
+                else
+                {
+                    if(GUILayout.Button("Use Enemy Modifiers"))
+                    {
+                        m_usingEnemyModifiers = true;
+                    }
                 }
             }
 

--- a/Assets/Editor/GameSettingsEditor.cs
+++ b/Assets/Editor/GameSettingsEditor.cs
@@ -33,6 +33,7 @@ namespace ILOVEYOU.EditorScript
         SerializedProperty m_spawnCapProp;
         SerializedProperty m_modListProp;
         SerializedProperty m_modChanceProp;
+        SerializedProperty m_modCapProp;
         SerializedProperty m_colorsProp;
         //Dictionary<string, object> SavedValues = new();
         //bool cardsEnabled = true;
@@ -152,6 +153,7 @@ namespace ILOVEYOU.EditorScript
             m_spawnCapProp = serializedObject.FindProperty("m_spawnCap");
             m_modListProp = serializedObject.FindProperty("m_modList");
             m_modChanceProp = serializedObject.FindProperty("m_modChanceOverTime");
+            m_modCapProp = serializedObject.FindProperty("m_modCountOverTime");
             m_colorsProp = serializedObject.FindProperty("m_prefColors");
         }
         public override void OnInspectorGUI()
@@ -329,6 +331,7 @@ namespace ILOVEYOU.EditorScript
                     {
                         EditorGUILayout.PropertyField(m_modListProp, new GUIContent("Mod list"));
                         EditorGUILayout.PropertyField(m_modChanceProp, new GUIContent("Mod chance"));
+                        EditorGUILayout.PropertyField(m_modCapProp, new GUIContent("Maximum Mod Count"));
                         if(GUILayout.Button("Remove Enemy Modifiers"))
                         {
                             m_usingEnemyModifiers = false;

--- a/Assets/Objects/Modifiers.meta
+++ b/Assets/Objects/Modifiers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e87bd5bea38f1e40983d0210a7e20d8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Modifiers/Images.meta
+++ b/Assets/Objects/Modifiers/Images.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 06f9296ffd3a8ad449317216abc5c783
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Objects/Modifiers/Images/ModifierIconTemplate.prefab
+++ b/Assets/Objects/Modifiers/Images/ModifierIconTemplate.prefab
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1542140600664575446
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9179890280423720149}
+  - component: {fileID: 772325828132243906}
+  - component: {fileID: 9166163142981481167}
+  m_Layer: 6
+  m_Name: ModifierIconTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9179890280423720149
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542140600664575446}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &772325828132243906
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542140600664575446}
+  m_CullTransparentMesh: 1
+--- !u!114 &9166163142981481167
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1542140600664575446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: ce16fddbb3b016940982cd1db7861402, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Objects/Modifiers/Images/ModifierIconTemplate.prefab.meta
+++ b/Assets/Objects/Modifiers/Images/ModifierIconTemplate.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4a09c8d50cbd58a479b07dd901c5a1dd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemies/Templates/BasicEnemy.prefab
+++ b/Assets/Prefabs/Enemies/Templates/BasicEnemy.prefab
@@ -140,7 +140,7 @@ MonoBehaviour:
   m_ChildControlHeight: 0
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
+  m_ReverseArrangement: 1
 --- !u!114 &1991006776517492539
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Enemies/Templates/BasicEnemy.prefab
+++ b/Assets/Prefabs/Enemies/Templates/BasicEnemy.prefab
@@ -1,5 +1,160 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &48946850673537457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7938655120826373128}
+  - component: {fileID: 7553762378069456590}
+  - component: {fileID: 5672239983229473980}
+  - component: {fileID: 820118022893264667}
+  - component: {fileID: 6121735272887592733}
+  - component: {fileID: 6571215920722161770}
+  - component: {fileID: 1991006776517492539}
+  m_Layer: 6
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7938655120826373128
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7613335133617298297}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.5}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &7553762378069456590
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &5672239983229473980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &820118022893264667
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &6121735272887592733
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15393c76250a94e48a24527a4a677d1a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &6571215920722161770
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1991006776517492539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 48946850673537457}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 1
+  m_VerticalFit: 0
 --- !u!1 &280319605076655441
 GameObject:
   m_ObjectHideFlags: 0
@@ -190,6 +345,7 @@ Transform:
   m_Children:
   - {fileID: 8443657717946065738}
   - {fileID: 6200019169468903389}
+  - {fileID: 7938655120826373128}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -209,7 +365,6 @@ MonoBehaviour:
   m_maxHealth: 10
   m_deathTimeout: 10
   m_distanceCondition: 1
-  m_stunnedRecoveryTime: 0
   m_obscureMask:
     serializedVersion: 2
     m_Bits: 2048

--- a/Assets/Scripts/EnemySystem/Enemy Child Scripts/BossEnemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy Child Scripts/BossEnemy.cs
@@ -23,10 +23,10 @@ namespace ILOVEYOU
 
             private bool m_charging = false;
 
-            public override void Initialize(Transform target)
+            public override void Initialize(Transform target, EnemyModifier[] mods = null)
             {
                 m_lungeCooldown = m_lungeTime;
-                base.Initialize(target);
+                base.Initialize(target, mods);
                 m_pattern.AddTarget(m_playerTransform);
 
                 m_maxSpeed = m_agent.speed;

--- a/Assets/Scripts/EnemySystem/Enemy Child Scripts/LungeEnemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy Child Scripts/LungeEnemy.cs
@@ -14,10 +14,10 @@ namespace ILOVEYOU
             private float m_tempSpeed = 0f;
 
             // Start is called before the first frame update
-            public override void Initialize(Transform target)
+            public override void Initialize(Transform target, EnemyModifier[] mods = null)
             {
                 m_lungeCooldown = m_lungeTime;
-                base.Initialize(target);
+                base.Initialize(target, mods);
             }
 
             // Update is called once per frame

--- a/Assets/Scripts/EnemySystem/Enemy Child Scripts/ProjectileEnemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy Child Scripts/ProjectileEnemy.cs
@@ -8,9 +8,9 @@ namespace ILOVEYOU
         {
             BulletPattern m_pattern;
 
-            public override void Initialize(Transform target)
+            public override void Initialize(Transform target, EnemyModifier[] mods = null)
             {
-                base.Initialize(target);
+                base.Initialize(target, mods);
                 m_pattern.AddTarget(m_playerTransform);
             }
             void Awake()

--- a/Assets/Scripts/EnemySystem/Enemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using ILOVEYOU.Shader;
 using UnityEngine.AI;
 using System.Collections;
+using ILOVEYOU.UI;
 namespace ILOVEYOU
 {
     namespace EnemySystem
@@ -46,6 +47,7 @@ namespace ILOVEYOU
             {
                 m_rigidBody = GetComponent<Rigidbody>();
                 m_playerTransform = target;
+                GetComponentInChildren<ModifierDisplay>().GetCamera = m_playerTransform.GetComponentInChildren<Camera>().transform;
                 m_blinkScript = GetComponent<DamageBlink>();
                 m_agent = GetComponent<NavMeshAgent>();
                 m_anim = GetComponentInChildren<Animator>();
@@ -62,6 +64,7 @@ namespace ILOVEYOU
                 foreach(var mod in mods)
                 {
                     mod.ApplyModifications(this);
+                    GetComponentInChildren<ModifierDisplay>().AddModifierToDisplay(mod.GetIcon);
                 }
 
                 //Potential TODO: add a "modifier" value that is dependent on current difficulty/time that influences the base values

--- a/Assets/Scripts/EnemySystem/Enemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy.cs
@@ -10,7 +10,9 @@ namespace ILOVEYOU
         public class Enemy : MonoBehaviour
         {
             [SerializeField] protected float m_damage = 1f;
+            public float GetSetDamage { get { return m_damage; } set { m_damage = value; } }
             [SerializeField] protected float m_maxHealth = 1f;
+            public float GetSetMaxHealth { get { return m_maxHealth; } set { m_maxHealth = value; } }
             protected float m_currentHealth = 1f;
             [SerializeField] protected float m_deathTimeout = 10f;
             [SerializeField] protected float m_distanceCondition = 1f;
@@ -40,10 +42,7 @@ namespace ILOVEYOU
             protected Animator m_anim;
 
             private DamageBlink m_blinkScript;
-            //this is used for the enemy hurtbox script
-            public float GetDamage() { return m_damage; }
-
-            public virtual void Initialize(Transform target)
+            public virtual void Initialize(Transform target, EnemyModifier[] mods = null)
             {
                 m_rigidBody = GetComponent<Rigidbody>();
                 m_playerTransform = target;
@@ -59,6 +58,11 @@ namespace ILOVEYOU
                 rotation = Quaternion.Euler(0f, rotation.eulerAngles.y, 0f);
                 //sets rotation
                 transform.rotation = rotation;
+
+                foreach(var mod in mods)
+                {
+                    mod.ApplyModifications(this);
+                }
 
                 //Potential TODO: add a "modifier" value that is dependent on current difficulty/time that influences the base values
             }
@@ -216,7 +220,18 @@ namespace ILOVEYOU
                 return true;
             }
 
-            
+            public virtual bool HealDamage(float health, bool clampResult = true)
+            {
+                if (m_isDead)
+                    return false;
+
+                m_currentHealth += health;
+
+                if (clampResult)
+                    m_currentHealth = Mathf.Clamp(m_currentHealth, 0, m_maxHealth);
+
+                return true;
+            }
         }
     }
 }

--- a/Assets/Scripts/EnemySystem/Enemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy.cs
@@ -66,6 +66,7 @@ namespace ILOVEYOU
                     mod.ApplyModifications(this);
                     GetComponentInChildren<ModifierDisplay>().AddModifierToDisplay(mod.GetIcon);
                 }
+                GetComponentInChildren<ModifierDisplay>().FixModImages();
 
                 //Potential TODO: add a "modifier" value that is dependent on current difficulty/time that influences the base values
             }

--- a/Assets/Scripts/EnemySystem/EnemyHurtBox.cs
+++ b/Assets/Scripts/EnemySystem/EnemyHurtBox.cs
@@ -15,7 +15,7 @@ namespace ILOVEYOU
 
             private void Awake()
             {
-                m_damage = GetComponentInParent<Enemy>().GetDamage();
+                m_damage = GetComponentInParent<Enemy>().GetSetDamage;
             }
 
             public void OnTriggerStay(Collider collision)

--- a/Assets/Scripts/EnemySystem/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySystem/EnemySpawner.cs
@@ -156,8 +156,9 @@ namespace ILOVEYOU
                     {
                         int rndMod = Random.Range(0, entries.Length);
                         float modChance = Random.Range(0f, 1f);
-                        if(modChance <= entries[rndMod].Chance)
-                            mods.Add(entries[rndMod].Modifier);
+                        if (entries[rndMod].Modifier.IsStackable || !mods.Contains(entries[rndMod].Modifier))
+                            if (modChance <= entries[rndMod].Chance)
+                                mods.Add(entries[rndMod].Modifier);
                     }
                 }
 

--- a/Assets/Scripts/EnemySystem/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySystem/EnemySpawner.cs
@@ -148,17 +148,13 @@ namespace ILOVEYOU
                 List<EnemyModifier> mods = new();
                 if (entries.Length > 0)
                 {
-                    float rnd = Random.Range(0f, 1f);
-                    if (rnd <= GameSettings.Current.GetModChance)
+                    int rolls = Mathf.FloorToInt(GameSettings.Current.GetMaxModCount);
+                    for (int i = 0; i < rolls; i++)
                     {
-                        foreach (var mod in entries)
-                        {
-                            float rndMod = Random.Range(0f, 1f);
-                            if(rndMod <= mod.Chance)
-                            {
-                                mods.Add(mod.Modifier);
-                            }
-                        }
+                        int rndMod = Random.Range(0, entries.Length);
+                        float modChance = Random.Range(0f, 1f);
+                        if(modChance <= entries[rndMod].Chance)
+                            mods.Add(entries[rndMod].Modifier);
                     }
                 }
 

--- a/Assets/Scripts/EnemySystem/EnemySpawner.cs
+++ b/Assets/Scripts/EnemySystem/EnemySpawner.cs
@@ -142,8 +142,29 @@ namespace ILOVEYOU
                     Debug.Log("Max number of enemies reached!");
                     return false;
                 }
+
+                //try for a modifier
+                GameSettings.ModListEntry[] entries = GameSettings.Current.GetModList;
+                List<EnemyModifier> mods = new();
+                if (entries.Length > 0)
+                {
+                    float rnd = Random.Range(0f, 1f);
+                    if (rnd <= GameSettings.Current.GetModChance)
+                    {
+                        foreach (var mod in entries)
+                        {
+                            float rndMod = Random.Range(0f, 1f);
+                            if(rndMod <= mod.Chance)
+                            {
+                                mods.Add(mod.Modifier);
+                            }
+                        }
+                    }
+                }
+
                 //creates enemy from given prefab
                 GameObject enemy = Instantiate(prefab);
+
                 //attempts 100 times to spawn an enemy
                 for (int i = 0; i < 100; i++)
                 {
@@ -156,7 +177,7 @@ namespace ILOVEYOU
                     if(!Physics.CheckSphere(enemy.transform.position, 1f, m_spawnMask))
                     {
                         //intializes enemy script
-                        enemy.GetComponent<Enemy>().Initialize(transform);
+                        enemy.GetComponent<Enemy>().Initialize(transform, mods.ToArray());
                         m_enemyObjects.Add(enemy);
                         return true;
                     }

--- a/Assets/Scripts/EnemySystem/Modifiers.meta
+++ b/Assets/Scripts/EnemySystem/Modifiers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25fff9951079ffa4cafd41eb15db86b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
+++ b/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
@@ -7,9 +7,11 @@ namespace ILOVEYOU.EnemySystem
     {
         [SerializeField] private Image m_ModifierIcon;
         public Image GetIcon => m_ModifierIcon;
+        [SerializeField] private bool m_stackable = false;
+        public bool IsStackable => m_stackable;
         public virtual bool ApplyModifications(Enemy target)
         {
-            return false;
+            return true;
         }
     }
 }

--- a/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
+++ b/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
@@ -6,6 +6,7 @@ namespace ILOVEYOU.EnemySystem
     public class EnemyModifier : ScriptableObject
     {
         [SerializeField] private Image m_ModifierIcon;
+        public Image GetIcon => m_ModifierIcon;
         public virtual bool ApplyModifications(Enemy target)
         {
             return false;

--- a/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
+++ b/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace ILOVEYOU.EnemySystem
+{
+    public class EnemyModifier : ScriptableObject
+    {
+        [SerializeField] private Image m_ModifierIcon;
+        public virtual bool ApplyModifications(Enemy target)
+        {
+            return false;
+        }
+    }
+}

--- a/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs.meta
+++ b/Assets/Scripts/EnemySystem/Modifiers/EnemyModifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdd75edc8da3874292103820b1ae6e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemySystem/Modifiers/ObjectSpawningModifier.cs
+++ b/Assets/Scripts/EnemySystem/Modifiers/ObjectSpawningModifier.cs
@@ -1,0 +1,21 @@
+using ILOVEYOU.EnemySystem;
+using ILOVEYOU.Environment;
+using UnityEngine;
+
+namespace ILOVEYOU.EnemySystem
+{
+    [CreateAssetMenu(fileName = "New Object Spawing Modifier", menuName = "ILOVEYOU Objects/Enemy Modifiers/Object Spawner")]
+    public class ObjectSpawningModifier : EnemyModifier
+    {
+        [SerializeField] private GameObject[] m_objectsToSpawn;
+        [SerializeField] private ObjectSpawner.SpawnStyle m_spawnStyle;
+        [SerializeField] private float m_timeBetweenSpawns;
+        [SerializeField] private float m_objectLifetime;
+        [SerializeField] private int m_indexOrCount;
+
+        public override bool ApplyModifications(Enemy target)
+        {
+            return target.gameObject.AddComponent<ObjectSpawner>().Initialize(m_objectsToSpawn, m_spawnStyle, m_timeBetweenSpawns, m_objectLifetime, m_indexOrCount);
+        }
+    }
+}

--- a/Assets/Scripts/EnemySystem/Modifiers/ObjectSpawningModifier.cs.meta
+++ b/Assets/Scripts/EnemySystem/Modifiers/ObjectSpawningModifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2267a5bf7f5df61448a3cb04e94b9b58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemySystem/Modifiers/SimpleEnemyModifier.cs
+++ b/Assets/Scripts/EnemySystem/Modifiers/SimpleEnemyModifier.cs
@@ -1,0 +1,104 @@
+using ILOVEYOU.Management;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace ILOVEYOU.EnemySystem
+{
+    [CreateAssetMenu(fileName = "New Simple Modifier", menuName = "ILOVEYOU Objects/Enemy Modifiers/Simple")]
+    public class SimpleEnemyModifier : EnemyModifier
+    {
+        [Flags]
+        private enum ModifierType
+        {
+            None,
+            Damage  = 1,
+            Health  = 2,
+            Speed   = 4,
+            Size    = 8
+        };
+        [SerializeField] private ModifierType m_modType;
+        private enum ModifierOperation
+        {
+            Add,
+            Sub,
+            Mul,
+            Div,
+            Set
+        }
+        [SerializeField] private ModifierOperation m_operation;
+        [SerializeField] private AnimationCurve m_value;
+        public override bool ApplyModifications(Enemy target)
+        {
+            if(m_modType.HasFlag(ModifierType.Damage))
+            {
+                Debug.Log("using damage");
+                target.GetSetDamage = _applyValue(target.GetSetDamage, m_value.Evaluate(GameManager.Instance.GetCurrentDifficulty));
+
+            }
+            if(m_modType.HasFlag(ModifierType.Health))
+            {
+                Debug.Log("using health");
+                target.GetSetMaxHealth = _applyValue(target.GetSetMaxHealth, m_value.Evaluate(GameManager.Instance.PercentToMaxDiff));
+            }
+            if (m_modType.HasFlag(ModifierType.Speed))
+            {
+                NavMeshAgent agent = target.GetComponent<NavMeshAgent>();
+                agent.speed = _applyValue(agent.speed, m_value.Evaluate(GameManager.Instance.GetCurrentDifficulty));
+
+            }
+            if (m_modType.HasFlag(ModifierType.Size))
+            {
+                target.transform.localScale = _applyValue(target.transform.localScale, m_value.Evaluate(GameManager.Instance.PercentToMaxDiff));
+            }
+            return false;
+        }
+        private float _applyValue(float variable, float v)
+        {
+            switch (m_operation)
+            {
+                case ModifierOperation.Add:
+                    variable += v;
+                    break;
+                case ModifierOperation.Sub:
+                    variable -= v;
+                    break;
+                case ModifierOperation.Mul:
+                    variable *= v;
+                    break;
+                case ModifierOperation.Div:
+                    variable /= v;
+                    break;
+                case ModifierOperation.Set:
+                    variable = v;
+                    break;
+            }
+            return variable;
+        }
+        private Vector3 _applyValue(Vector3 variable, float v)
+        {
+            switch (m_operation)
+            {
+                case ModifierOperation.Add:
+                    variable += new Vector3(v, v, v);
+                    break;
+                case ModifierOperation.Sub:
+                    variable -= new Vector3(v, v, v);
+                    break;
+                case ModifierOperation.Mul:
+                    variable *= v;
+                    break;
+                case ModifierOperation.Div:
+                    variable /= v;
+                    break;
+                case ModifierOperation.Set:
+                    variable = new Vector3(v, v, v);
+                    break;
+            }
+            return variable;
+        }
+    }
+}

--- a/Assets/Scripts/EnemySystem/Modifiers/SimpleEnemyModifier.cs.meta
+++ b/Assets/Scripts/EnemySystem/Modifiers/SimpleEnemyModifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 297d25717f397e245be1f28e015424f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Environment/ObjectSpawner.cs
+++ b/Assets/Scripts/Environment/ObjectSpawner.cs
@@ -1,0 +1,113 @@
+using ILOVEYOU.Hazards;
+using System.Collections;
+using System.Collections.Generic;
+using Unity.VisualScripting;
+using UnityEngine;
+
+namespace ILOVEYOU.Environment
+{
+    public class ObjectSpawner : MonoBehaviour
+    {
+        [SerializeField] private GameObject[] m_objectList;
+        private int m_index;
+        public enum SpawnStyle
+        {
+            Single,
+            RoundRobin,
+            Random,
+            RandomCount,
+            All,
+        }
+        [SerializeField] private SpawnStyle m_spawnMethod;
+        [SerializeField] private float m_timeBetweenSpawns;
+        private float m_countdown;
+        [SerializeField] private float m_objectLifetime = 1;
+
+        public bool Initialize(GameObject[] objs, SpawnStyle style, float time, float lifetime, int index = 0)
+        {
+            m_objectList = objs;
+            m_spawnMethod = style;
+            m_timeBetweenSpawns = time;
+            m_countdown = m_timeBetweenSpawns;
+            m_objectLifetime = lifetime;
+            m_index = index;
+            return true;
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
+            if(m_countdown <= 0)
+            {
+                m_countdown = m_timeBetweenSpawns;
+                _spawnObjects();
+            }
+            else
+            {
+                m_countdown -= Time.deltaTime;
+            }
+        }
+        private void _spawnObjects()
+        {
+            switch (m_spawnMethod)
+            {
+                case SpawnStyle.Single:
+                    {
+                        GameObject newObject = Instantiate(m_objectList[m_index]);
+                        newObject.transform.position = transform.position;
+                        _hazardCheck(newObject);
+                        Destroy(newObject, m_objectLifetime);
+                    }
+                    break;
+                case SpawnStyle.RoundRobin:
+                    {
+                        GameObject newObject = Instantiate(m_objectList[m_index]);
+                        newObject.transform.position = transform.position;
+                        _hazardCheck(newObject);
+                        Destroy(newObject, m_objectLifetime);
+
+                        m_index++;
+                        if(m_index >= m_objectList.Length)
+                            m_index = 0;
+                    }
+                    break;
+                case SpawnStyle.Random:
+                    {
+                        int rnd = Random.Range(0, m_objectList.Length);
+                        GameObject newObject = Instantiate(m_objectList[rnd]);
+                        newObject.transform.position = transform.position;
+                        _hazardCheck(newObject);
+                        Destroy(newObject, m_objectLifetime);
+                    }
+                    break;
+                case SpawnStyle.RandomCount:
+                    for(int i = 0; i < m_index; i++)
+                    {
+                        int rnd = Random.Range(0, m_objectList.Length);
+                        GameObject newObject = Instantiate(m_objectList[rnd]);
+                        newObject.transform.position = transform.position;
+                        _hazardCheck(newObject);
+                        Destroy(newObject, m_objectLifetime);
+                    }
+                    break;
+                case SpawnStyle.All:
+                    foreach(var obj in m_objectList)
+                    {
+                        GameObject newObject = Instantiate(obj);
+                        newObject.transform.position = transform.position;
+                        _hazardCheck(newObject);
+                        Destroy(newObject, m_objectLifetime);
+                    }
+                    break;
+            }
+        }
+        private void _hazardCheck(GameObject obj)
+        {
+            HazardObject hazard = obj.GetComponent<HazardObject>();
+            if (hazard)
+            {
+                hazard.EnableHazard(m_objectLifetime);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Environment/ObjectSpawner.cs.meta
+++ b/Assets/Scripts/Environment/ObjectSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f56532668f570fc49ac8c19271d16f6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Settings/GameSettings.cs
+++ b/Assets/Scripts/Settings/GameSettings.cs
@@ -80,9 +80,10 @@ namespace ILOVEYOU.Management
         }
         [SerializeField] private ModListEntry[] m_modList = new ModListEntry[0];
         public ModListEntry[] GetModList => m_modList;
-        [SerializeField] public AnimationCurve m_modChanceOverTime;
+        [SerializeField] private AnimationCurve m_modChanceOverTime;
         public float GetModChance => m_modChanceOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
-
+        [SerializeField] private AnimationCurve m_modCountOverTime;
+        public float GetMaxModCount => m_modCountOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
         [System.Serializable]
         public struct ColorPrefType
         {

--- a/Assets/Scripts/Settings/GameSettings.cs
+++ b/Assets/Scripts/Settings/GameSettings.cs
@@ -72,6 +72,16 @@ namespace ILOVEYOU.Management
         public AnimationCurve GetSpawnTime => m_spawnTime;
         [SerializeField] private AnimationCurve m_spawnCap;
         public AnimationCurve GetSpawnCap => m_spawnCap;
+        [System.Serializable]
+        public struct ModListEntry
+        {
+            public EnemyModifier Modifier;
+            public float Chance;
+        }
+        [SerializeField] private ModListEntry[] m_modList = new ModListEntry[0];
+        public ModListEntry[] GetModList => m_modList;
+        [SerializeField] public AnimationCurve m_modChanceOverTime;
+        public float GetModChance => m_modChanceOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
 
         [System.Serializable]
         public struct ColorPrefType

--- a/Assets/Scripts/UI/ModifierDisplay.cs
+++ b/Assets/Scripts/UI/ModifierDisplay.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace ILOVEYOU.UI
+{
+    public class ModifierDisplay : MonoBehaviour
+    {
+        private Transform m_targetCam;
+        public Transform GetCamera { get { return m_targetCam; } set { m_targetCam = value; } }
+        public void AddModifierToDisplay(Image modImage)
+        {
+            //create a new image instance as a child
+            Image newImage = Instantiate(modImage);
+            newImage.transform.SetParent(transform, false);
+            newImage.transform.localScale = Vector3.one;
+        }
+
+        // Update is called once per frame
+        void Update()
+        {
+            transform.LookAt(m_targetCam.transform);
+        }
+    }
+}

--- a/Assets/Scripts/UI/ModifierDisplay.cs
+++ b/Assets/Scripts/UI/ModifierDisplay.cs
@@ -12,7 +12,13 @@ namespace ILOVEYOU.UI
             //create a new image instance as a child
             Image newImage = Instantiate(modImage);
             newImage.transform.SetParent(transform, false);
-            newImage.transform.localScale = Vector3.one;
+        }
+        public void FixModImages()
+        {
+            foreach(var child in transform.GetComponentsInChildren<Image>())
+            {
+                child.rectTransform.sizeDelta = Vector2.one / transform.parent.localScale;
+            }
         }
 
         // Update is called once per frame

--- a/Assets/Scripts/UI/ModifierDisplay.cs.meta
+++ b/Assets/Scripts/UI/ModifierDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15393c76250a94e48a24527a4a677d1a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Enemies can now spawn with modifiers!
Modifiers are set in the game settings objects and can be disabled completely or per enemy group*.
There's currently 2 types of modifiers, simple - which can change stats of the enemy; and object spawning - which spawns objects on the enemy.
To create a new modifier, they can be found under "ILOVEYOU Object/Enemy Modifiers" and more can be created from the base class.

*When an enemy respawns, they can have modifiers even if not normally meant to - this is funny so I have left it in.