### PR TITLE
Updated card chance rolling.

### DIFF
--- a/Assets/Scripts/Cards/CardManager.cs
+++ b/Assets/Scripts/Cards/CardManager.cs
@@ -13,11 +13,15 @@ namespace ILOVEYOU
         public class CardData
         {
             public DisruptCard DisruptCard;
+            [Tooltip("The chance of a card dropping over the round time")]
             public AnimationCurve ChanceOverTime;
+            [Tooltip("The chance of a card dropping over the enemy count of the calling object.\nUnseen AI will take the average of all other players' enemy counts instead.")]
             public AnimationCurve ChanceOverEnemyCount;
+            [Tooltip("The chacne of a card dropping over the health differene of the calling object to the other players.\nUnseen AI will just use the average health of all players instead.")]
             public AnimationCurve ChanceOverHealthDelta;
+            [Tooltip("If this card can drop when other player have a boss.")]
             public bool AllowWithBoss = true;
-            [HideInInspector] public float CurrentChance;
+            public float CurrentChance { get; private set; }
 
             public float GenerateChance(PlayerManager player)
             {

--- a/Assets/Scripts/Cards/CardManager.cs
+++ b/Assets/Scripts/Cards/CardManager.cs
@@ -21,51 +21,58 @@ namespace ILOVEYOU
 
             public float GenerateChance(PlayerManager player)
             {
-                float[] chances = new float[3];
-                //Chances if called from player
-                if (player)
-                {
-                    //Check if this card can be used with a boss while its active...
-                    foreach (var other in GameManager.Instance.GetOtherPlayers(player))
-                    {
-                        if (BossEnemy.Instances[other.GetPlayerID] != null && !AllowWithBoss)
-                        {
-                            //...if not, set the chance to 0
-                            return CurrentChance = 0;
-                        }
-                    }
+                //Get all the other players
+                PlayerManager[] others = GameManager.Instance.GetOtherPlayers(player);
 
-                    //Create an array for the values used to find the chance.
-                    //Get the game time compared to max diffculty
-                    chances[0] = ChanceOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
-                    //Get the percent of enemies on this players side
-                    chances[1] = ChanceOverEnemyCount.Evaluate(player.GetLevelManager.GetSpawner.PercentToMaxEnemies);
-                    //Get the health difference between this and the other player.
-                    float averageHealth = 0;
-                    //Average the other players' health values
-                    PlayerManager[] others = GameManager.Instance.GetOtherPlayers(player);
-                    for (int i = 0; i < others.Length; i++)
+                //fails if any other player has the boss active.
+                if(!AllowWithBoss)
+                foreach(var p in others)
+                {
+                    if (BossEnemy.Instances[p.GetPlayerID] != null && BossEnemy.Instances[p.GetPlayerID].GetCurrentHealth > 0)
                     {
-                        averageHealth += others[i].GetControls.GetHealthPercent;
+                        return CurrentChance = 0;
                     }
-                    averageHealth /= others.Length;
-                    chances[2] = ChanceOverHealthDelta.Evaluate(Mathf.Clamp(averageHealth - player.GetControls.GetHealthPercent, 0, 1));
                 }
+
+                float[] chances = new float[3];
+
+                //Get the current difficulty
+                chances[0] = ChanceOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
+                
+                //Get the current enemy count
+                if(player != null)
+                {
+                    chances[1] = ChanceOverEnemyCount.Evaluate(player.GetLevelManager.GetSpawner.PercentToMaxEnemies);
+                }
+                //If there is no player manager, get the average enemy count of the other player.
                 else
                 {
-                    PlayerManager[] others = GameManager.Instance.GetOtherPlayers(null);
-                    foreach(var other in others)
+                    float sum = 0;
+                    foreach(var p in others)
                     {
-                        if (BossEnemy.Instances[other.GetPlayerID] != null && !AllowWithBoss)
-                        {
-                            return CurrentChance = 0;
-                        }
+                        sum += p.GetLevelManager.GetSpawner.PercentToMaxEnemies;
                     }
-                    chances[0] = ChanceOverTime.Evaluate(GameManager.Instance.PercentToMaxDiff);
-                    chances[1] = 1;
-                    chances[2] = 1;
+                    chances[1] = sum / others.Length;
                 }
 
+                //Get the average health for all other players
+                float healthSum = 0;
+                foreach(var p in others)
+                {
+                    healthSum += p.GetControls.GetHealthPercent;
+                }
+                healthSum /= others.Length;
+
+                //Compare this health average to the caller's current health.
+                if(player != null)
+                {
+                    chances[2] = ChanceOverHealthDelta.Evaluate(Mathf.Clamp(healthSum - player.GetControls.GetHealthPercent, 0, 1));
+                }
+                //If there is no caller, just use the average health.
+                else
+                {
+                    chances[2] = ChanceOverHealthDelta.Evaluate(healthSum);
+                }
 
                 //Mult all the chance values for the final result
                 float result = 1;
@@ -110,6 +117,8 @@ namespace ILOVEYOU
 
                 //Make a new array for the requested cards
                 List<DisruptCard> selectedCards = new();
+                //Update the chances of the cards dropping
+                UpdateChances(GameSettings.Current.GetCardData, player);
                 //Get enough cards
                 for (int c = 0; c < count; c++)
                 {
@@ -150,17 +159,21 @@ namespace ILOVEYOU
                 m_onDispenseCard.Invoke();
                 return cards;
             }
+            static public CardData[] UpdateChances(CardData[] array, PlayerManager player = null)
+            {
+                foreach (var data in array)
+                {
+                    data.GenerateChance(player);
+                }
+                return array;
+            }
             static public DisruptCard GetRandomCard(CardData[] array, int attempts = 100)
             {
-                foreach(var data in array)
-                {
-                    data.GenerateChance(null);
-                }
                 for (int i = attempts; i > 0; i--)
                 {
-
                     float rndChance = Random.Range(0.00f, 1.00f);
                     int rndCard = Random.Range(0, array.Length);
+                    Debug.Log($"Pulled card at index {rndCard}");
                     if (array[rndCard].CurrentChance >= rndChance)
                         return array[rndCard].DisruptCard;
                 }

--- a/Assets/Scripts/EnemySystem/Enemy.cs
+++ b/Assets/Scripts/EnemySystem/Enemy.cs
@@ -17,6 +17,7 @@ namespace ILOVEYOU
             [SerializeField] protected float m_maxHealth = 1f;
             public float GetSetMaxHealth { get { return m_maxHealth; } set { m_maxHealth = value; } }
             protected float m_currentHealth = 1f;
+            public float GetCurrentHealth => m_currentHealth;
             [SerializeField] protected float m_deathTimeout = 10f;
             [SerializeField] protected float m_distanceCondition = 1f;
             [SerializeField] protected bool m_canBeStunned = false;

--- a/Assets/Scripts/Management/GameManager.cs
+++ b/Assets/Scripts/Management/GameManager.cs
@@ -39,6 +39,7 @@ namespace ILOVEYOU
                 }
                 else
                 {
+                    CardManager.UpdateChances(GameSettings.Current.GetUnseenCards);
                     CardManager.GetRandomCard(GameSettings.Current.GetUnseenCards).ExecuteEvents(null);
                     m_countdown = GameSettings.Current.GetUnseenCardRate;
                 }

--- a/Assets/Settings/Game Settings/MainSettings.asset
+++ b/Assets/Settings/Game Settings/MainSettings.asset
@@ -74,7 +74,7 @@ MonoBehaviour:
       m_PostInfinity: 2
       m_RotationOrder: 4
     AllowWithBoss: 1
-    CurrentChance: 1
+    CurrentChance: 0.5
   - DisruptCard: {fileID: 2943384210519268959, guid: 313118f0d262fc64090349f7082b78b9, type: 3}
     ChanceOverTime:
       serializedVersion: 2
@@ -140,7 +140,7 @@ MonoBehaviour:
       m_PostInfinity: 2
       m_RotationOrder: 4
     AllowWithBoss: 1
-    CurrentChance: 1
+    CurrentChance: 0.27098483
   - DisruptCard: {fileID: 4827626793003550405, guid: 9445586d2e239764abe3ce16ee0270f0, type: 3}
     ChanceOverTime:
       serializedVersion: 2
@@ -302,7 +302,7 @@ MonoBehaviour:
       m_PostInfinity: 0
       m_RotationOrder: 0
     AllowWithBoss: 1
-    CurrentChance: 1
+    CurrentChance: 0.54196966
   - DisruptCard: {fileID: 4248793250358130411, guid: fdbefdc97ddd78643ad6c91b7b376199, type: 3}
     ChanceOverTime:
       serializedVersion: 2
@@ -386,7 +386,7 @@ MonoBehaviour:
       m_PostInfinity: 0
       m_RotationOrder: 0
     AllowWithBoss: 1
-    CurrentChance: 0.25679865
+    CurrentChance: 0.24324296
   - DisruptCard: {fileID: 3063484218868929400, guid: 80f3a9c1d8a308a43a2a9b8d3f078461, type: 3}
     ChanceOverTime:
       serializedVersion: 2
@@ -443,7 +443,7 @@ MonoBehaviour:
       m_PostInfinity: 0
       m_RotationOrder: 0
     AllowWithBoss: 1
-    CurrentChance: 1
+    CurrentChance: 1.0050939
   - DisruptCard: {fileID: 938783057243066637, guid: 27302251ee741cb49851d9d5a55fb851, type: 3}
     ChanceOverTime:
       serializedVersion: 2
@@ -506,19 +506,19 @@ MonoBehaviour:
         inWeight: 0
         outWeight: 0
       - serializedVersion: 3
-        time: 1
-        value: 1
-        inSlope: 2
-        outSlope: 2
+        time: 0.8
+        value: 2
+        inSlope: 6.164538
+        outSlope: 6.164538
         tangentMode: 0
         weightedMode: 0
-        inWeight: 0
+        inWeight: 0.049874336
         outWeight: 0
       m_PreInfinity: 2
       m_PostInfinity: 2
       m_RotationOrder: 0
-    AllowWithBoss: 1
-    CurrentChance: 1
+    AllowWithBoss: 0
+    CurrentChance: 0.007958369
   m_playerHealth: 15
   m_iframes: 1
   m_playerSpeed: 10


### PR DESCRIPTION
Behavior of this function should be more consistent now. "Chance Over Enemy Count" and "Chance Over Health Delta" have been updated. EC now checks the caller's enemy count. If called by the unseen AI, it instead uses the the other players' counts. HD when called from the AI now just uses the health of the other players. Moved the updating of chances into its own function - it was being called every time cards where being requested. Enemy current health can now be read.